### PR TITLE
fix: Update install instructions to use `go install` rather than `go get`

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The repositories queried are:
 ## installation 
 
 ```bash
-go get github.com/philroche/wolfi-package-status
+go install github.com/philroche/wolfi-package-status@latest
 ```
 ## usage
 


### PR DESCRIPTION
`go get` can not be used outside a module. `go install` is for local binary installation.

Signed-off-by: philroche <phil.roche@chainguard.dev>
